### PR TITLE
Add support for Ares (on Windows, Linux and Mac)

### DIFF
--- a/src/MultiClient/CMakeLists.txt
+++ b/src/MultiClient/CMakeLists.txt
@@ -2,5 +2,7 @@ file(GLOB_RECURSE SOURCES "*.c")
 include_directories("${CMAKE_SOURCE_DIR}/include" "${CMAKE_SOURCE_DIR}/src")
 
 add_executable(MultiClient ${SOURCES})
-target_link_libraries(MultiClient Ws2_32.lib)
+if(WIN32)
+    target_link_libraries(MultiClient Ws2_32.lib)
+endif()
 install(TARGETS MultiClient DESTINATION .)

--- a/src/MultiClient/app.c
+++ b/src/MultiClient/app.c
@@ -138,7 +138,7 @@ int appStartAres(App* app, const char* host, uint16_t port)
     {
         ret = connect(sock, ptr->ai_addr, (int)ptr->ai_addrlen);
         printf("[ares] connect: %d %d %s %p\n", ret, WSAGetLastError(), strerror(WSAGetLastError()), ptr);
-        if (ret == 0 || (ret == SOCKET_ERROR && WSAGetLastError() == WSAEINPROGRESS)) {
+        if (ret == 0 || (ret == SOCKET_ERROR && (WSAGetLastError() == WSAEINPROGRESS || WSAGetLastError() == WSAEWOULDBLOCK))) {
             printf("[ares] connection in progress...\n");
             break;
         }

--- a/src/MultiClient/app.c
+++ b/src/MultiClient/app.c
@@ -137,9 +137,9 @@ int appStartAres(App* app, const char* host, uint16_t port)
     for (ptr = result; ptr != NULL; ptr = ptr->ai_next)
     {
         ret = connect(sock, ptr->ai_addr, (int)ptr->ai_addrlen);
-        printf("[ares] connect: %d %d %s %p\n", ret, WSAGetLastError(), strerror(WSAGetLastError()), ptr);
+        // printf("[ares] connect: %d %d %s %p\n", ret, WSAGetLastError(), strerror(WSAGetLastError()), ptr);
         if (ret == 0 || (ret == SOCKET_ERROR && (WSAGetLastError() == WSAEINPROGRESS || WSAGetLastError() == WSAEWOULDBLOCK))) {
-            printf("[ares] connection in progress...\n");
+            // printf("[ares] connection in progress...\n");
             break;
         }
     }
@@ -233,11 +233,11 @@ static void appCheckAres(App* app)
     if (ret < 1)
         return;
 
-    printf("[ares] connection completed\n");
+    // printf("[ares] connection completed\n");
     error = 0;
     len = sizeof(error);
     if (getsockopt(app->socketAres, SOL_SOCKET, SO_ERROR, &error, &len) < 0 || error != 0) {        
-        fprintf(stderr, "[ares] connection failed: %d %s\n", error, strerror(error));
+        // fprintf(stderr, "[ares] connection failed: %d %s\n", error, strerror(error));
         closesocket(app->socketAres);
         app->socketAres = INVALID_SOCKET;
         return;

--- a/src/MultiClient/app.c
+++ b/src/MultiClient/app.c
@@ -73,13 +73,8 @@ int appListen(App* app, const char* host, uint16_t port)
     }
 
     /* Set the socket to non-blocking */
-#ifdef _WIN32
-    u_long mode = 1;
-    ret = ioctlsocket(sock, FIONBIO, &mode);
-#else
-    int mode = fcntl(sock, F_GETFL, 0);
-    ret = fcntl(sock, F_SETFL, mode | O_NONBLOCK);
-#endif
+    ret = sockasync(sock, 1);
+
     if (ret == SOCKET_ERROR)
     {
         fprintf(stderr, "Unable to set socket to non-blocking\n");
@@ -103,13 +98,7 @@ static void appAccept(App* app)
         return;
 
     /* Make the socket blocking */
-#ifdef _WIN32
-    mode = 0;
-    ioctlsocket(sock, FIONBIO, &mode);
-#else
-    mode = fcntl(sock, F_GETFL, 0);
-    fcntl(sock, F_SETFL, mode & ~O_NONBLOCK);
-#endif
+    sockasync(sock, 0);
 
     /* Create game */
     for (int i = 0; i < MAX_GAMES; ++i)

--- a/src/MultiClient/app.c
+++ b/src/MultiClient/app.c
@@ -137,9 +137,9 @@ int appStartAres(App* app, const char* host, uint16_t port)
     for (ptr = result; ptr != NULL; ptr = ptr->ai_next)
     {
         ret = connect(sock, ptr->ai_addr, (int)ptr->ai_addrlen);
-        // printf("[ares] connect: %d %d %s %p\n", ret, WSAGetLastError(), strerror(WSAGetLastError()), ptr);
+        printf("[ares] connect: %d %d %s %p\n", ret, WSAGetLastError(), strerror(WSAGetLastError()), ptr);
         if (ret == 0 || (ret == SOCKET_ERROR && WSAGetLastError() == WSAEINPROGRESS)) {
-            // printf("ok\n");
+            printf("[ares] connection in progress...\n");
             break;
         }
     }
@@ -233,9 +233,11 @@ static void appCheckAres(App* app)
     if (ret < 1)
         return;
 
+    printf("[ares] connection completed\n");
     error = 0;
     len = sizeof(error);
     if (getsockopt(app->socketAres, SOL_SOCKET, SO_ERROR, &error, &len) < 0 || error != 0) {        
+        fprintf(stderr, "[ares] connection failed: %d %s\n", error, strerror(error));
         closesocket(app->socketAres);
         app->socketAres = INVALID_SOCKET;
         return;

--- a/src/MultiClient/app.c
+++ b/src/MultiClient/app.c
@@ -291,7 +291,7 @@ int appRun(App* app, const char *host, uint16_t port)
                 continue;
             gameTick(app, g);
         }
-        Sleep(10);
+        Sleep(100);
     }
     return 0;
 }

--- a/src/MultiClient/app.c
+++ b/src/MultiClient/app.c
@@ -73,8 +73,13 @@ int appListen(App* app, const char* host, uint16_t port)
     }
 
     /* Set the socket to non-blocking */
+#ifdef _WIN32
     u_long mode = 1;
     ret = ioctlsocket(sock, FIONBIO, &mode);
+#else
+    int mode = fcntl(sock, F_GETFL, 0);
+    ret = fcntl(sock, F_SETFL, mode | O_NONBLOCK);
+#endif
     if (ret == SOCKET_ERROR)
     {
         fprintf(stderr, "Unable to set socket to non-blocking\n");
@@ -98,8 +103,13 @@ static void appAccept(App* app)
         return;
 
     /* Make the socket blocking */
+#ifdef _WIN32
     mode = 0;
     ioctlsocket(sock, FIONBIO, &mode);
+#else
+    mode = fcntl(sock, F_GETFL, 0);
+    fcntl(sock, F_SETFL, mode & ~O_NONBLOCK);
+#endif
 
     /* Create game */
     for (int i = 0; i < MAX_GAMES; ++i)

--- a/src/MultiClient/game.c
+++ b/src/MultiClient/game.c
@@ -595,6 +595,7 @@ void gameTick(App* app, Game* game)
 {
     if (apiContextLock(game))
     {
+        printf("Game API tick\n");
         gameApiTick(game);
         apiContextUnlock(game);
     }

--- a/src/MultiClient/game.c
+++ b/src/MultiClient/game.c
@@ -42,7 +42,7 @@ static void gameServerReconnect(Game* game)
     game->state = STATE_CONNECT;
 }
 
-void gameInit(Game* game, SOCKET sock)
+void gameInit(Game* game, SOCKET sock, int apiProtocol)
 {
     /* Set initial values */
     game->valid = 1;
@@ -51,8 +51,10 @@ void gameInit(Game* game, SOCKET sock)
     game->nopAcc = 0;
     game->timeout = 0;
     game->apiError = 0;
+    game->apiProtocol = apiProtocol;
     game->socketApi = sock;
     game->socketServer = INVALID_SOCKET;
+    protocolInit(game);
 
     netBufInit(&game->tx);
 

--- a/src/MultiClient/game.c
+++ b/src/MultiClient/game.c
@@ -593,9 +593,10 @@ static void gameServerTick(App* app, Game* game)
 
 void gameTick(App* app, Game* game)
 {
+    LOGF("Game tick\n");
     if (apiContextLock(game))
     {
-        printf("Game API tick\n");
+        LOGF("Game API tick\n");
         gameApiTick(game);
         apiContextUnlock(game);
     }
@@ -605,4 +606,5 @@ void gameTick(App* app, Game* game)
         printf("Game disconnected\n");
         gameClose(game);
     }
+    LOGF("Game tick end\n");
 }

--- a/src/MultiClient/game.c
+++ b/src/MultiClient/game.c
@@ -498,13 +498,7 @@ static void gameServerConnect(App* app, Game* game)
         }
 
         /* Make the socket blocking */
-        #ifdef _WIN32
-        mode = 0;
-        ioctlsocket(game->socketServer, FIONBIO, &mode);
-        #else
-        mode = fcntl(game->socketServer, F_GETFL, 0);
-        fcntl(game->socketServer, F_SETFL, mode & ~O_NONBLOCK);
-        #endif
+        sockasync(game->socketServer, 0);
 
         /* Send the initial message */
         memcpy(buf, "OOMM2", 5);
@@ -533,13 +527,7 @@ static void gameServerConnect(App* app, Game* game)
         memcpy(&game->clientId, buf + 9, 2);
 
         /* Make the socket non blocking */
-        #ifdef _WIN32
-        mode = 1;
-        ioctlsocket(game->socketServer, FIONBIO, &mode);
-        #else
-        mode = fcntl(game->socketServer, F_GETFL, 0);
-        fcntl(game->socketServer, F_SETFL, mode | O_NONBLOCK);
-        #endif
+        sockasync(game->socketServer, 1);
 
         break;
     }

--- a/src/MultiClient/game.c
+++ b/src/MultiClient/game.c
@@ -498,8 +498,13 @@ static void gameServerConnect(App* app, Game* game)
         }
 
         /* Make the socket blocking */
+        #ifdef _WIN32
         mode = 0;
         ioctlsocket(game->socketServer, FIONBIO, &mode);
+        #else
+        mode = fcntl(game->socketServer, F_GETFL, 0);
+        fcntl(game->socketServer, F_SETFL, mode & ~O_NONBLOCK);
+        #endif
 
         /* Send the initial message */
         memcpy(buf, "OOMM2", 5);
@@ -528,8 +533,13 @@ static void gameServerConnect(App* app, Game* game)
         memcpy(&game->clientId, buf + 9, 2);
 
         /* Make the socket non blocking */
+        #ifdef _WIN32
         mode = 1;
         ioctlsocket(game->socketServer, FIONBIO, &mode);
+        #else
+        mode = fcntl(game->socketServer, F_GETFL, 0);
+        fcntl(game->socketServer, F_SETFL, mode | O_NONBLOCK);
+        #endif
 
         break;
     }

--- a/src/MultiClient/main.c
+++ b/src/MultiClient/main.c
@@ -25,7 +25,12 @@ int main(int argc, char** argv)
 
     if (appInit(&app))
         return 1;
-    if (appListen(&app, "localhost", 13249))
+    if (appStartPj64(&app, "localhost", 13249))
+    {
+        appQuit(&app);
+        return 1;
+    }
+    if (appStartAres(&app, "localhost", 9123))
     {
         appQuit(&app);
         return 1;

--- a/src/MultiClient/multi.h
+++ b/src/MultiClient/multi.h
@@ -211,6 +211,7 @@ void        protocolInit(Game* game);
 uint8_t     protocolRead8(Game* game, uint32_t addr);
 uint16_t    protocolRead16(Game* game, uint32_t addr);
 uint32_t    protocolRead32(Game* game, uint32_t addr);
+void        protocolReadBuffer(Game *game, uint32_t addr, int count, uint8_t *buffer);
 void        protocolWrite8(Game* game, uint32_t addr, uint8_t value);
 void        protocolWrite16(Game* game, uint32_t addr, uint16_t value);
 void        protocolWrite32(Game* game, uint32_t addr, uint32_t value);

--- a/src/MultiClient/multi.h
+++ b/src/MultiClient/multi.h
@@ -1,6 +1,8 @@
 #ifndef MULTI_H
 #define MULTI_H
 
+#define LOG_DEBUG    0
+
 #ifdef _WIN32
     #define _WIN32_LEAN_AND_MEAN 1
     #define _CRT_SECURE_NO_WARNINGS 1
@@ -25,6 +27,7 @@
 
     static inline void LOGF(const char* fmt, ...)
     {
+        #if LOG_DEBUG
         FILETIME ft;
         GetSystemTimePreciseAsFileTime(&ft);
         SYSTEMTIME st;
@@ -34,6 +37,7 @@
         va_start(args, fmt);
         vprintf(fmt, args);
         va_end(args);
+        #endif
     }
 #else
     typedef int SOCKET;
@@ -82,7 +86,7 @@
 
     static inline void LOGF(const char* fmt, ...)
     {
-        // print timestamp in milliseconds
+        #if LOG_DEBUG
         struct timeval tv;
         gettimeofday(&tv, NULL);
         struct tm* tm = localtime(&tv.tv_sec);
@@ -91,6 +95,7 @@
         va_start(args, fmt);
         vprintf(fmt, args);
         va_end(args);
+        #endif
     }
 #endif
 

--- a/src/MultiClient/multi.h
+++ b/src/MultiClient/multi.h
@@ -7,6 +7,12 @@
     #include <winsock2.h>
     #include <ws2tcpip.h>
     #include <windows.h>
+
+    static inline int sockasync(SOCKET sock, int enable)
+    {
+        u_long mode = enable ? 1 : 0;
+        return ioctlsocket(sock, FIONBIO, &mode);
+    }
 #else
     typedef int SOCKET;
     #include <unistd.h>
@@ -34,6 +40,18 @@
     #define _chsize_s(fd, size)     ftruncate(fd, size)
     #define MAX_PATH                16384
     #define TIMEVAL                 struct timeval
+
+    static inline int sockasync(SOCKET sock, int enable)
+    {
+        int mode = fcntl(sock, F_GETFL, 0);
+        if (mode == -1)
+            return -1;
+        if (enable)
+            mode |= O_NONBLOCK;
+        else
+            mode &= ~O_NONBLOCK;
+        return fcntl(sock, F_SETFL, mode);
+    }
 #endif
 
 #include <stdio.h>

--- a/src/MultiClient/multi.h
+++ b/src/MultiClient/multi.h
@@ -1,11 +1,41 @@
 #ifndef MULTI_H
 #define MULTI_H
 
-#define _WIN32_LEAN_AND_MEAN 1
-#define _CRT_SECURE_NO_WARNINGS 1
-#include <winsock2.h>
-#include <ws2tcpip.h>
-#include <windows.h>
+#ifdef _WIN32
+    #define _WIN32_LEAN_AND_MEAN 1
+    #define _CRT_SECURE_NO_WARNINGS 1
+    #include <winsock2.h>
+    #include <ws2tcpip.h>
+    #include <windows.h>
+#else
+    typedef int SOCKET;
+    #include <unistd.h>
+    #include <sys/socket.h>
+    #include <sys/types.h>
+    #include <sys/stat.h>
+    #include <netdb.h>
+    #include <fcntl.h>
+    #include <errno.h>
+
+    #define INVALID_SOCKET          (-1)
+    #define SOCKET_ERROR            (-1)
+
+    #define WSADATA                 int
+    #define WSAStartup(x,y)         (0)
+    #define WSACleanup()            (0)
+    #define WSAGetLastError()       (errno)
+    #define WSAEWOULDBLOCK          EWOULDBLOCK
+    #define WSAEINPROGRESS          EINPROGRESS
+
+    #define Sleep(x)                usleep((x)*1000)
+    #define closesocket(fd)         close(fd)
+    #define _mkdir(x)               mkdir(x, 0777)
+    #define _fileno(x)              fileno(x)
+    #define _chsize_s(fd, size)     ftruncate(fd, size)
+    #define MAX_PATH                16384
+    #define TIMEVAL                 struct timeval
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/MultiClient/protocol.c
+++ b/src/MultiClient/protocol.c
@@ -161,7 +161,7 @@ static int aresCommandWrite(Game* game, uint32_t addr, int size, uint32_t value)
 
 static uint32_t aresRead(Game* game, uint32_t addr, int size)
 {
-    printf("aresRead(%08x, %d)\n", addr, size);
+    LOGF("aresRead(%08x, %d)\n", addr, size);
     uint32_t value;
     if (!aresCommandRead(game, addr, size, &value))
     {
@@ -176,7 +176,7 @@ static uint32_t aresRead(Game* game, uint32_t addr, int size)
 
 static void aresWrite(Game* game, uint32_t addr, uint32_t value, int size)
 {
-    printf("aresWrite(%08x, %08x, %d)\n", addr, value, size);
+    LOGF("aresWrite(%08x, %08x, %d)\n", addr, value, size);
     if (!aresCommandWrite(game, addr, size, value))
     {
         game->apiError = 1;

--- a/src/MultiClient/protocol.c
+++ b/src/MultiClient/protocol.c
@@ -103,7 +103,7 @@ static int aresCommandRead(Game* game, uint32_t addr, int count, uint8_t *value)
     LOGF("aresRead(%08x, %d)\n", addr, count);
     printf("    => ");
 
-    char buf[32];
+    char buf[256];
     sprintf(buf, "m%08x,%x", addr, count);
     for (int i = 0; buf[i] != 0; ++i)
         checksum += buf[i];

--- a/src/MultiClient/protocol.c
+++ b/src/MultiClient/protocol.c
@@ -84,14 +84,27 @@ static void aresStart(Game* game)
     }
 }
 
-static int aresCommandRead(Game* game, uint32_t addr, int size, uint32_t *value)
+static uint8_t unhex(char ch) {
+    if (ch >= '0' && ch <= '9')
+        return ch - '0';
+    if (ch >= 'A' && ch <= 'F')
+        return ch - 'A' + 10;
+    if (ch >= 'a' && ch <= 'f')
+        return ch - 'a' + 10;
+    return 0;
+}
+
+static int aresCommandRead(Game* game, uint32_t addr, int count, uint8_t *value)
 {
     int read;
     int error = 0;
     uint8_t checksum = 0;
 
+    LOGF("aresRead(%08x, %d)\n", addr, count);
+    printf("    => ");
+
     char buf[32];
-    sprintf(buf, "m%08x,%x", addr, size);
+    sprintf(buf, "m%08x,%x", addr, count);
     for (int i = 0; buf[i] != 0; ++i)
         checksum += buf[i];
 
@@ -108,13 +121,18 @@ static int aresCommandRead(Game* game, uint32_t addr, int size, uint32_t *value)
     if (buf[0] != '+')
         return 0;
     
-    read = sockRecv(game->socketApi, buf, 1+size*2+3);
+    read = sockRecv(game->socketApi, buf, 1+count*2+3);
     if (read == 0)
         return 0;
     if (buf[0] != '$')
         return 0;
-    *value = strtoul(buf + 1, NULL, 16);
-    if (buf[1+size*2] != '#')
+    for (int i=0; i<count; i++) {
+        *value++ = (unhex(buf[1+i*2]) << 4) | unhex(buf[1+i*2+1]);
+        printf("%02x", value[-1]);
+    }
+    printf("\n");
+
+    if (buf[1+count*2] != '#')
         return 0;
 
     if (!sockSend(game->socketApi, "+", 1))
@@ -159,18 +177,22 @@ static int aresCommandWrite(Game* game, uint32_t addr, int size, uint32_t value)
     return 1;
 }
 
-static uint32_t aresRead(Game* game, uint32_t addr, int size)
+static uint32_t aresReadInt(Game* game, uint32_t addr, int size)
 {
-    LOGF("aresRead(%08x, %d)\n", addr, size);
-    uint32_t value;
-    if (!aresCommandRead(game, addr, size, &value))
+    uint8_t buf[4];
+    if (!aresCommandRead(game, addr, size, buf))
     {
         game->apiError = 1;
         closesocket(game->socketApi);
         game->socketApi = INVALID_SOCKET;
         return 0;
     }
-    printf("    => %08x\n", value);
+    uint32_t value;
+    switch (size) {
+    case 4: value = (buf[0] << 24) | (buf[1] << 16) | (buf[2] << 8) | buf[3]; break;
+    case 2: value = (buf[0] << 8) | buf[1]; break;
+    case 1: value = buf[0]; break;
+    }
     return value;
 }
 
@@ -194,7 +216,7 @@ uint8_t protocolRead8(Game* game, uint32_t addr)
         pj64Read(game, &value, 2, 1, addr);
         break;
     case PROTOCOL_ARES:
-        value = aresRead(game, addr, 1);
+        value = aresReadInt(game, addr, 1);
         break;
     }
     return value;
@@ -208,7 +230,7 @@ uint16_t protocolRead16(Game* game, uint32_t addr)
         pj64Read(game, &value, 3, 2, addr);
         break;
     case PROTOCOL_ARES:
-        value = aresRead(game, addr, 2);
+        value = aresReadInt(game, addr, 2);
         break;
     }
     return value;
@@ -222,10 +244,23 @@ uint32_t protocolRead32(Game* game, uint32_t addr)
         pj64Read(game, &value, 4, 4, addr);
         break;
     case PROTOCOL_ARES:
-        value = aresRead(game, addr, 4);
+        value = aresReadInt(game, addr, 4);
         break;
     }
     return value;
+}
+
+void protocolReadBuffer(Game *game, uint32_t addr, int count, uint8_t *buffer)
+{
+    switch (game->apiProtocol) {
+    case PROTOCOL_PJ64:
+        for (int i=0; i<count; i++)
+            *buffer++ = protocolRead8(game, addr+i);
+        break;
+    case PROTOCOL_ARES:
+        aresCommandRead(game, addr, count, buffer);
+        break;
+    }
 }
 
 void protocolWrite8(Game* game, uint32_t addr, uint8_t value)

--- a/src/MultiClient/protocol.c
+++ b/src/MultiClient/protocol.c
@@ -32,7 +32,7 @@ static int sockRecv(SOCKET s, void* data, uint32_t size)
     return 1;
 }
 
-static void protocolRead(Game* game, void* buf, uint8_t op, uint32_t size, uint32_t addr)
+static void pj64Read(Game* game, void* buf, uint8_t op, uint32_t size, uint32_t addr)
 {
     char packet[5];
 
@@ -54,7 +54,7 @@ static void protocolRead(Game* game, void* buf, uint8_t op, uint32_t size, uint3
     }
 }
 
-static void protocolWrite(Game* game, const void* buf, uint8_t op, uint32_t size, uint32_t addr)
+static void pj64Write(Game* game, const void* buf, uint8_t op, uint32_t size, uint32_t addr)
 {
     char packet[9];
 
@@ -70,38 +70,207 @@ static void protocolWrite(Game* game, const void* buf, uint8_t op, uint32_t size
     }
 }
 
+static void aresStart(Game* game)
+{
+    char packet[1];
+
+    packet[0] = '+';
+    if (!sockSend(game->socketApi, packet, 1))
+    {
+        game->apiError = 1;
+        closesocket(game->socketApi);
+        game->socketApi = INVALID_SOCKET;
+        return;
+    }
+}
+
+static int aresCommandRead(Game* game, uint32_t addr, int size, uint32_t *value)
+{
+    int read;
+    int error = 0;
+    uint8_t checksum = 0;
+
+    char buf[32];
+    sprintf(buf, "m%08x,%x", addr, size);
+    for (int i = 0; buf[i] != 0; ++i)
+        checksum += buf[i];
+
+    error |= !sockSend(game->socketApi, "$", 1);
+    error |= !sockSend(game->socketApi, buf, strlen(buf));
+    sprintf(buf, "#%02x", checksum);
+    error |= !sockSend(game->socketApi, buf, strlen(buf));
+    if (error)
+        return 0;
+
+    read = sockRecv(game->socketApi, buf, 1);
+    if (read == 0)
+        return 0;
+    if (buf[0] != '+')
+        return 0;
+    
+    read = sockRecv(game->socketApi, buf, 1+size*2+3);
+    if (read == 0)
+        return 0;
+    if (buf[0] != '$')
+        return 0;
+    *value = strtoul(buf + 1, NULL, 16);
+    if (buf[1+size*2] != '#')
+        return 0;
+
+    if (!sockSend(game->socketApi, "+", 1))
+        return 0;
+    return 1;
+}
+
+static int aresCommandWrite(Game* game, uint32_t addr, int size, uint32_t value)
+{
+    int read;
+    int error = 0;
+    uint8_t checksum = 0;
+
+    char buf[32];
+    sprintf(buf, "M%08x,%x:%0*X", addr, size, size*2, value);
+    for (int i = 0; buf[i] != 0; ++i)
+        checksum += buf[i];
+
+    error |= !sockSend(game->socketApi, "$", 1);
+    error |= !sockSend(game->socketApi, buf, strlen(buf));
+    sprintf(buf, "#%02x", checksum);
+    error |= !sockSend(game->socketApi, buf, strlen(buf));
+    if (error)
+        return 0;
+
+    read = sockRecv(game->socketApi, buf, 1);
+    if (read == 0)
+        return 0;
+    if (buf[0] != '+')
+        return 0;
+    
+    read = sockRecv(game->socketApi, buf, 1+2+3);
+    if (read == 0)
+        return 0;
+    if (buf[0] != '$')
+        return 0;
+    if (strncmp(buf + 1, "OK#", 3) != 0)
+        return 0;
+
+    if (!sockSend(game->socketApi, "+", 1))
+        return 0;
+    return 1;
+}
+
+static uint32_t aresRead(Game* game, uint32_t addr, int size)
+{
+    printf("aresRead(%08x, %d)\n", addr, size);
+    uint32_t value;
+    if (!aresCommandRead(game, addr, size, &value))
+    {
+        game->apiError = 1;
+        closesocket(game->socketApi);
+        game->socketApi = INVALID_SOCKET;
+        return 0;
+    }
+    printf("    => %08x\n", value);
+    return value;
+}
+
+static void aresWrite(Game* game, uint32_t addr, uint32_t value, int size)
+{
+    printf("aresWrite(%08x, %08x, %d)\n", addr, value, size);
+    if (!aresCommandWrite(game, addr, size, value))
+    {
+        game->apiError = 1;
+        closesocket(game->socketApi);
+        game->socketApi = INVALID_SOCKET;
+    }
+}
+
+
 uint8_t protocolRead8(Game* game, uint32_t addr)
 {
     uint8_t value;
-    protocolRead(game, &value, 2, 1, addr);
+    switch (game->apiProtocol) {
+    case PROTOCOL_PJ64:
+        pj64Read(game, &value, 2, 1, addr);
+        break;
+    case PROTOCOL_ARES:
+        value = aresRead(game, addr, 1);
+        break;
+    }
     return value;
 }
 
 uint16_t protocolRead16(Game* game, uint32_t addr)
 {
     uint16_t value;
-    protocolRead(game, &value, 3, 2, addr);
+    switch (game->apiProtocol) {
+    case PROTOCOL_PJ64:
+        pj64Read(game, &value, 3, 2, addr);
+        break;
+    case PROTOCOL_ARES:
+        value = aresRead(game, addr, 2);
+        break;
+    }
     return value;
 }
 
 uint32_t protocolRead32(Game* game, uint32_t addr)
 {
     uint32_t value;
-    protocolRead(game, &value, 4, 4, addr);
+    switch (game->apiProtocol) {
+    case PROTOCOL_PJ64:
+        pj64Read(game, &value, 4, 4, addr);
+        break;
+    case PROTOCOL_ARES:
+        value = aresRead(game, addr, 4);
+        break;
+    }
     return value;
 }
 
 void protocolWrite8(Game* game, uint32_t addr, uint8_t value)
 {
-    protocolWrite(game, &value, 6, 1, addr);
+    switch (game->apiProtocol) {
+    case PROTOCOL_PJ64:
+        pj64Write(game, &value, 6, 1, addr);
+        break;
+    case PROTOCOL_ARES:
+        aresWrite(game, addr, value, 1);
+        break;
+    }
 }
 
 void protocolWrite16(Game* game, uint32_t addr, uint16_t value)
 {
-    protocolWrite(game, &value, 7, 2, addr);
+    switch (game->apiProtocol) {
+    case PROTOCOL_PJ64:
+        pj64Write(game, &value, 7, 2, addr);
+        break;
+    case PROTOCOL_ARES:
+        aresWrite(game, addr, value, 2);
+        break;
+    }
 }
 
 void protocolWrite32(Game* game, uint32_t addr, uint32_t value)
 {
-    protocolWrite(game, &value, 8, 4, addr);
+    switch (game->apiProtocol) {
+    case PROTOCOL_PJ64:
+        pj64Write(game, &value, 8, 4, addr);
+        break;
+    case PROTOCOL_ARES:
+        aresWrite(game, addr, value, 4);
+        break;
+    }
+}
+
+void protocolInit(Game* game)
+{
+    switch (game->apiProtocol) {
+    case PROTOCOL_PJ64:
+        break;
+    case PROTOCOL_ARES:
+        aresStart(game);
+        break;
+    }
 }

--- a/src/MultiClient/sendq.c
+++ b/src/MultiClient/sendq.c
@@ -1,6 +1,8 @@
 #include "multi.h"
+#ifdef _WIN32
 #include <direct.h>
 #include <io.h>
+#endif
 
 #define SQ_TTL 2000
 


### PR DESCRIPTION
This PR adds support to connect to Ares. It includes some wider refactoring:

* Allow compilation on Linux and Mac
* Add Ares codepath, in which multiclient connects to Ares using the gdb protocol.
* Improve speed by coalescing reads of arrays in single calls
* Improve speed by bumping polling time to 100ms
* Add some timestamped logging, disabled with a compile time flag

Some changes have been made to Ares as well, so use the nightly build, until the next Ares version is released (Ares v139).

