### PR TITLE
Ares performance

### DIFF
--- a/src/MultiClient/app.c
+++ b/src/MultiClient/app.c
@@ -133,6 +133,10 @@ int appStartAres(App* app, const char* host, uint16_t port)
         return 1;
     }
 
+    /* Set TCP_NODELAY / disable Nagle algorithm, we need very low latency during an API tick */
+    int tcpNodelayOption = 1;
+    ret = setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (char *)&tcpNodelayOption, sizeof(int));
+
     /* Connect to the server */
     for (ptr = result; ptr != NULL; ptr = ptr->ai_next)
     {

--- a/src/MultiClient/multi.h
+++ b/src/MultiClient/multi.h
@@ -220,6 +220,7 @@ void        protocolReadBuffer(Game *game, uint32_t addr, int count, uint8_t *bu
 void        protocolWrite8(Game* game, uint32_t addr, uint8_t value);
 void        protocolWrite16(Game* game, uint32_t addr, uint16_t value);
 void        protocolWrite32(Game* game, uint32_t addr, uint32_t value);
+void        protocolWriteBuffer(Game* game, uint32_t addr, int count, uint8_t *value);
 
 int         apiContextLock(Game* game);
 void        apiContextUnlock(Game* game);

--- a/src/MultiClient/multi.h
+++ b/src/MultiClient/multi.h
@@ -48,6 +48,7 @@
     #include <sys/time.h>
     #include <arpa/inet.h>
     #include <netdb.h>
+    #include <netinet/tcp.h>
     #include <fcntl.h>
     #include <errno.h>
     #include <stdio.h>

--- a/src/MultiClient/protocol.c
+++ b/src/MultiClient/protocol.c
@@ -100,8 +100,7 @@ static int aresCommandRead(Game* game, uint32_t addr, int count, uint8_t *value)
     int error = 0;
     uint8_t checksum = 0;
 
-    LOGF("aresRead(%08x, %d)\n", addr, count);
-    printf("    => ");
+    LOGF("aresRead(%08x, %d)\n    => ", addr, count);
 
     char buf[256];
     sprintf(buf, "m%08x,%x", addr, count);
@@ -128,9 +127,9 @@ static int aresCommandRead(Game* game, uint32_t addr, int count, uint8_t *value)
         return 0;
     for (int i=0; i<count; i++) {
         *value++ = (unhex(buf[1+i*2]) << 4) | unhex(buf[1+i*2+1]);
-        printf("%02x", value[-1]);
+        if (LOG_DEBUG) printf("%02x", value[-1]);
     }
-    printf("\n");
+    if (LOG_DEBUG) printf("\n");
 
     if (buf[1+count*2] != '#')
         return 0;
@@ -160,7 +159,7 @@ static int aresCommandWrite(Game* game, uint32_t addr, int size, uint8_t *value)
     }
     sprintf(buf, "#%02x", checksum);
     error |= !sockSend(game->socketApi, buf, strlen(buf));
-    
+
     if (error)
         return 0;
 

--- a/src/MultiClient/protocol.c
+++ b/src/MultiClient/protocol.c
@@ -310,6 +310,19 @@ void protocolWrite32(Game* game, uint32_t addr, uint32_t value)
     }
 }
 
+void protocolWriteBuffer(Game* game, uint32_t addr, int count, uint8_t *buffer)
+{
+    switch (game->apiProtocol) {
+    case PROTOCOL_PJ64:
+        for (int i = 0; i < count; i ++) 
+            protocolWrite8(game, addr+i, buffer[i]);
+        break;
+    case PROTOCOL_ARES:
+        aresCommandWrite(game, addr, count, buffer);
+        break;
+    }
+}
+
 void protocolInit(Game* game)
 {
     switch (game->apiProtocol) {


### PR DESCRIPTION
* Set TCP_NODELAY on Ares TCP sockets. Massively reduces latency during game tick on Linux, where this option is not default.
* Refactor write protocol to better match the read API and write arbitrary length buffers. If Rasky's multibyte writes make it into Ares, this will make it easy to refactor some writes into larger batch writes, perhaps improving performance a bit.
* Hide exposed memory read logging behind the `LOG_DEBUG` flag.